### PR TITLE
Efficient data.table conversion

### DIFF
--- a/R/pd_add_pip_vars.R
+++ b/R/pd_add_pip_vars.R
@@ -174,7 +174,7 @@ add_pip_vars.default <- function(df, cpfw, cpi, ppp, pop, ...) {
       assign(fnms[i], data.table::copy(rr))
 
     } else {
-      assign(fnms[i], data.table::as.data.table(rr))
+      assign(fnms[i], qDT(rr))
     }
 
   }
@@ -349,7 +349,7 @@ ppp_to_wide <- function(ppp) {
   if (inherits(ppp, "data.table")) {
     ppp <- data.table::copy(ppp)
   } else {
-    ppp <- data.table::as.data.table(ppp)
+    ppp <- qDT(ppp)
   }
   stopifnot( exprs = {
 
@@ -408,7 +408,7 @@ get_welfare_ppp <- function(df, base_year) {
   if (inherits(df, "data.table")) {
     dt <- data.table::copy(df)
   } else {
-    dt <- data.table::as.data.table(df)
+    dt <- qDT(df)
   }
 
   stopifnot( exprs = {

--- a/R/pd_add_pip_vars.R
+++ b/R/pd_add_pip_vars.R
@@ -171,7 +171,7 @@ add_pip_vars.default <- function(df, cpfw, cpi, ppp, pop, ...) {
   for (i in seq_along(fnms)) {
     rr <- get(fnms[[i]])
     if (inherits(rr, "data.table")) {
-      assign(fnms[i], data.table::copy(rr))
+      assign(fnms[i], copy(rr))
 
     } else {
       assign(fnms[i], qDT(rr))
@@ -202,7 +202,7 @@ add_pip_vars.default <- function(df, cpfw, cpi, ppp, pop, ...) {
 
   df[, reporting_level := get(select_var)]
 
-  data.table::setorder(df, reporting_level)
+  setorder(df, reporting_level)
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ## Deflated data --------
@@ -347,7 +347,7 @@ ppp_to_wide <- function(ppp) {
 #   ____________________________________________________________________________
 #   Defenses                                                           ####
   if (inherits(ppp, "data.table")) {
-    ppp <- data.table::copy(ppp)
+    ppp <- copy(ppp)
   } else {
     ppp <- qDT(ppp)
   }
@@ -377,7 +377,7 @@ ppp_to_wide <- function(ppp) {
                formula = country_code + ppp_data_level ~ ppp_version,
                value.var = "ppp",
   )
-  data.table::setattr(ppp, "ppp_versions", ppp_v)
+  setattr(ppp, "ppp_versions", ppp_v)
 
 
 
@@ -406,7 +406,7 @@ get_welfare_ppp <- function(df, base_year) {
   #   ____________________________________________________________________________
   #   Defenses                                                                ####
   if (inherits(df, "data.table")) {
-    dt <- data.table::copy(df)
+    dt <- copy(df)
   } else {
     dt <- qDT(df)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,7 +23,7 @@ uniq_vars <- function(x) {
 #' @noRd
 check_data_table <- function(x) {
   if (!is.data.table(x)) {
-    x <- as.data.table(x)
+    x <- qDT(x)
   }
   x
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,7 +80,7 @@ vars_to_list <- function(x, vars, nm = NULL) {
 #'   variables as attributes
 #' @export
 #' @examples
-#' dt <- data.table::data.table(a = 1, b = 1:10, c = 5)
+#' dt <- data.table(a = 1, b = 1:10, c = 5)
 #' out <- uniq_vars_to_attr(dt)
 #' out[]
 #' attr(out, "a")

--- a/man/pipdata.Rd
+++ b/man/pipdata.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/pipdata.R
 \docType{package}
 \name{pipdata}
-\alias{-package}
 \alias{pipdata}
 \alias{.datatable.aware}
 \title{A package for prepare data to be ingested in PIP pipeline}

--- a/man/uniq_vars_to_attr.Rd
+++ b/man/uniq_vars_to_attr.Rd
@@ -21,7 +21,7 @@ convert variables with unique values along the data set to attributes and then
 remove those unique variables
 }
 \examples{
-dt <- data.table::data.table(a = 1, b = 1:10, c = 5)
+dt <- data.table(a = 1, b = 1:10, c = 5)
 out <- uniq_vars_to_attr(dt)
 out[]
 attr(out, "a")


### PR DESCRIPTION
Small efficiency improvements

1. Replace `as.data.table()` with `qDT()`
2. Remove `data.table::` because already imported

Note that `collapse::qDT()` is much more efficient than `data.table::as.data.table()`

```
df1 <- data.frame(x = rnorm(1e7), 
                             y = rnorm(1e7))
df2 <- data.frame(x = rnorm(1e7),
                             y = rnorm(1e7))

mb(as.data.table = {
    dt1 <- as.data.table(df1)}, 
  qDT = {
    dt2 <- qDT(df2)})

identical(qDT(df1), 
          as.data.table(df1))
```

![image](https://github.com/PIP-Technical-Team/pipdata/assets/62433917/49b0c1a0-d443-48c2-951b-332ebacb4874)

Passing checks:

![image](https://github.com/PIP-Technical-Team/pipdata/assets/62433917/762f35ff-b2f9-4ed5-a14e-bb433e818ca7)

There is a note about the unexported function from `{wbpip}`
